### PR TITLE
Bug where optionals on objects weren't being correctly defined

### DIFF
--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -758,7 +758,10 @@ export class Parser {
                 console.log(`Warning: ${doclet.name} rest parameter should be an array`);
                 type.name = type.name + '[]'; // Must be an array
             }
-        } else if(doclet.optional === true) obj.flags |= dom.ParameterFlags.Optional; // Rest implies Optional
+        } else if (doclet.optional === true) {
+            if (obj["kind"] === "parameter") obj.flags |= dom.ParameterFlags.Optional; // Rest implies Optional
+            else obj.flags |= dom.DeclarationFlags.Optional; // Rest implies Optional
+        }
         switch(doclet.access) {
             case "protected": obj.flags |= dom.DeclarationFlags.Protected; break;
             case "private": obj.flags |= dom.DeclarationFlags.Private; break;


### PR DESCRIPTION
I noticed the properties marked as `[someVariable]` weren't turning in `someVariable?` in the d.ts file. The two enums in dts-dom are as follows:
```
export declare enum DeclarationFlags {
    None = 0,
    Private = 1,
    Protected = 2,
    Static = 4,
    Optional = 8,
    Export = 16,
    Abstract = 32,
    ExportDefault = 64,
    ReadOnly = 128,
}
export declare enum ParameterFlags {
    None = 0,
    Optional = 1,
    Rest = 2,
}
```
... so when we're `|=`ing flags between ParameterFlags and DeclarationFlags the values of the enums don't match up.