### PR TITLE
Fix for PluginObject::default Array type

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -539,7 +539,7 @@ declare type PluginObject = {
     /**
      * [description]
      */
-    default?: Array;
+    default?: Array<any>;
     /**
      * [description]
      */


### PR DESCRIPTION
When transpiling the phaser.d.ts file, there's an error claiming that Array has to be typed.

This seems to solve it.

Is it enough/valid?