### PR TITLE
Add local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can either:
 
 2. Or, you can checkout this repository and then read the documentation by pointing your browser to the local `docs/` folder. Again using the Classes and Namespaces links at the top of the page to navigate.
 
-You can also generate new docs locally by running `npm run gen` (and waiting a long time, it takes over an hour to build)
+You can also generate new docs locally by running `npm run gen` and waiting (it may take up to an hour to generate the docs). See [Generating the Docs Locally](#generating-the-docs-locally) below for more instructions.
 
 ## TypeScript Definitions
 
@@ -25,3 +25,9 @@ The defs generation tool is called `tsgen` and it's written in TypeScript. Build
 You can then run `npm run tsgen` to build the actual defs. Once the parser is built you only need use this command. Use it to re-generate the defs if you have modified the Phaser source code.
 
 There is also a test script available: `npm run test-ts` which will compile a test project and output any compilation errors to `output.txt`.
+
+## Generating the Docs Locally
+
+Phaser uses the popular [jsdoc](http://usejsdoc.org/), which means the documentation itself is written in the source code in the [Phaser](https://github.com/photonstorm/phaser/) repository. In order to regenerate the docs, you'll need to clone that repository and it must be in a folder named `phaser` in the parent directory.
+
+Then run `npm install` to install dependencies, and finally run `npm run gen`. The generated docs will be in a new directory called `out/`. Double click on `out/index.html` to browse the generated documentation.


### PR DESCRIPTION
This should resolve https://github.com/photonstorm/phaser3-docs/issues/63 by adding instructions in the README about how to build locally. It takes about 5-10 minutes to generate on my machine (which is a 5 years old i5 Windows lenovo laptop) so I relaxed the wording on "it takes an hour to generate". 

Wording suggestions/feedback welcome!