### PR TITLE
Add camera3d plugin to jsdoc config

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -9,7 +9,8 @@
     "source": {
         "include": [
             "../phaser/src/",
-            "../phaser/plugins/fbinstant"
+            "../phaser/plugins/fbinstant",
+            "../phaser/plugins/camera3d"
         ],
         "exclude": [
             "../phaser/src/physics/matter-js/poly-decomp/",


### PR DESCRIPTION
This is to fix https://github.com/photonstorm/phaser3-docs/issues/78.

I'm assuming `Sprite3D` is meant to be exposed in the docs, since it seems to be hand-coded in `template/publish.js`. This makes it show up in the navbar but it was never generating the HTML file for it. This fixes it. Tested locally to make sure it does generate the Spite3D file and the link works. 