### PR TITLE
Repair parser not recognize union type

### DIFF
--- a/tsgen/src/Parser.ts
+++ b/tsgen/src/Parser.ts
@@ -408,8 +408,12 @@ export class Parser {
             }
 
         } else {
-            type = dom.create.functionType(null, dom.type.void);
-            this.setParams(doclet, type);
+            if (doclet.type.names[0] == "function") {
+                type = dom.create.functionType(null, dom.type.void);
+                this.setParams(doclet, type);
+            } else {
+                type = this.parseType(doclet);
+            }
         }
 
         let alias = dom.create.alias(doclet.name, type);


### PR DESCRIPTION
I found that union types be incorrectly parsed as ()=>void;
I fixed it.

before: 
```typescript

type CenterType = ()=>void;
type OrientationType = ()=>void;
type ScaleModeType = ()=>void;
type ZoomType = ()=>void;
type ArcadeColliderType = ()=>void;
```

now:
```typescript
type CenterType = Phaser.Scale.Center.NO_CENTER | Phaser.Scale.Center.CENTER_BOTH | Phaser.Scale.Center.CENTER_HORIZONTALLY | Phaser.Scale.Center.CENTER_VERTICALLY;
type OrientationType = Phaser.Scale.Orientation.LANDSCAPE | Phaser.Scale.Orientation.PORTRAIT;
type ScaleModeType = Phaser.Scale.ScaleModes.NONE | Phaser.Scale.ScaleModes.WIDTH_CONTROLS_HEIGHT | Phaser.Scale.ScaleModes.HEIGHT_CONTROLS_WIDTH | Phaser.Scale.ScaleModes.FIT | Phaser.Scale.ScaleModes.ENVELOP | Phaser.Scale.ScaleModes.RESIZE;
type ZoomType = Phaser.Scale.Zoom.NO_ZOOM | Phaser.Scale.Zoom.ZOOM_2X | Phaser.Scale.Zoom.ZOOM_4X | Phaser.Scale.Zoom.MAX_ZOOM;
type ArcadeColliderType = Phaser.GameObjects.GameObject | Phaser.GameObjects.Group | Phaser.Physics.Arcade.Sprite | Phaser.Physics.Arcade.Image | Phaser.Physics.Arcade.StaticGroup | Phaser.Physics.Arcade.Group | Phaser.Tilemaps.DynamicTilemapLayer | Phaser.Tilemaps.StaticTilemapLayer | Phaser.GameObjects.GameObject[] | Phaser.Physics.Arcade.Sprite[] | Phaser.Physics.Arcade.Image[] | Phaser.Physics.Arcade.StaticGroup[] | Phaser.Physics.Arcade.Group[] | Phaser.Tilemaps.DynamicTilemapLayer[] | Phaser.Tilemaps.StaticTilemapLayer[];


```