### PR TITLE
Do not exclude DOM GO from json-docs generation.

### DIFF
--- a/jsdoc.data.json
+++ b/jsdoc.data.json
@@ -12,9 +12,7 @@
             "../phaser/src/phaser-core.js",
             "../phaser/src/physics/matter-js/poly-decomp/",
             "../phaser/src/physics/matter-js/lib",
-            "../phaser/src/polyfills",
-            "../phaser/src/core/CreateDOMContainer.js",
-            "../phaser/src/gameobjects/domelement/"
+            "../phaser/src/polyfills"
         ],
         "includePattern": ".+\\.js?$",
         "excludePattern": "(^|\\/|\\\\)_"


### PR DESCRIPTION
The DOM game object is not experimental anymore, so let's include them in the JSON-docs generation.