### PR TITLE
Fixes typo in POINTER_OUT

### DIFF
--- a/docs/Phaser.Input.Events.html
+++ b/docs/Phaser.Input.Events.html
@@ -6460,7 +6460,7 @@ the propagation of this event.</p>
     <div class="description">
         <p>The Pointer Out Input Event.</p>
 <p>This event is dispatched by the Input Plugin belonging to a Scene if a pointer moves out of any interactive Game Object.</p>
-<p>Listen to this event from within a Scene using: <code>this.input.on('pointerup', listener)</code>.</p>
+<p>Listen to this event from within a Scene using: <code>this.input.on('pointerout', listener)</code>.</p>
 <p>The event hierarchy is as follows:</p>
 <ol>
 <li><a href="Phaser.Input.Events.html#event:GAMEOBJECT_POINTER_OUT"><code>GAMEOBJECT_POINTER_OUT</code></a></li>


### PR DESCRIPTION
The event string for the POINTER_OUT section was 'pointerup', changed to 'pointerout'. If this is generated from somewhere else, let me know and I can try to find where that occurs.