### PR TITLE
Improve dashing config

### DIFF
--- a/dashing.json
+++ b/dashing.json
@@ -7,17 +7,33 @@
             {
                 "requiretext": "^Namespace:",
                 "type": "Namespace",
-                "matchpath": "docs/.*\\.html"
+                "regexp": "^Namespace\\:\\s",
+                "replacement": "",
+                "matchpath": "docs/(Phaser|Camera|Matter|Spine).*\\.html$"
             },
             {
                 "requiretext": "^Class:",
                 "type": "Class",
-                "matchpath": "docs/.*\\.html"
+                "regexp": "^Class\\:\\s",
+                "replacement": "",
+                "matchpath": "docs/(Phaser|Camera|Matter|Spine).*\\.html$"
             }
         ],
+        "dl > dt.name > h4": {
+            "type": "Member",
+            "regexp": "(\\:.+)|(<[^>]*>)",
+            "replacement": "",
+            "matchpath": "docs/(Phaser|Camera|Matter|Spine).*\\.html$"
+        },
+        "dl > dt > h4.name": {
+            "type": "Method",
+            "regexp": "\\(.*\\)|(<[^>]*>)",
+            "replacement": "",
+            "matchpath": "docs/(Phaser|Camera|Matter|Spine).*\\.html$"
+        },
         "h4[id^=\"event:\"]": {
             "type": "Event",
-            "matchpath": "docs/.*\\.html"
+            "matchpath": "docs/(Phaser|Camera|Matter|Spine).*\\.html$"
         }
     },
     "ignore": [],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sqldev": "npm run json && npm run sql",
     "types": "node src/types.js",
     "total": "node total.js",
-    "build-docset": "dashing build phaser"
+    "build-docset": "dashing build --source docs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was super happy to find a ready-made Dashing config in this repo. :)
After using it for a while I worked on some improvements:
1. Class members and methods are now detected and can be searched for more easily.
2. Some files are not indexed (such as `global.html`) as they were producing duplicates in the search index.
3. Specify the root directory when running via `npm run build-docset`. This reduces the docset size by quite a lot, especially when the user generated the `out/` folder for themselves (380MB -> 120MB in my case).

![Screenshot](https://user-images.githubusercontent.com/5478672/109399446-27a7a500-7943-11eb-9929-ab226139a1b1.png)